### PR TITLE
URL Cleanup

### DIFF
--- a/location-finder-form/pom.xml
+++ b/location-finder-form/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.integration.demo</groupId>

--- a/location-finder-form/src/main/resources/app-context.xml
+++ b/location-finder-form/src/main/resources/app-context.xml
@@ -7,13 +7,13 @@
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
 	xmlns:cloud="http://schema.cloudfoundry.org/spring"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
-		http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
-		http://schema.cloudfoundry.org/spring http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
+		http://www.springframework.org/schema/integration/amqp https://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
+		http://schema.cloudfoundry.org/spring https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:transformer input-channel="requestReceiveChannel" output-channel="searchFormReceiveChannel">
 		<bean class="module.c.RequestTransformer" />

--- a/location-finder-form/src/main/resources/servlet-config.xml
+++ b/location-finder-form/src/main/resources/servlet-config.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-http="http://www.springframework.org/schema/integration/http"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int-http:inbound-gateway request-channel="requestReceiveChannel"
 							  name="/searchForm" 

--- a/location-finder-form/src/main/webapp/WEB-INF/web.xml
+++ b/location-finder-form/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
+<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
   <listener>
     <listener-class>
 			org.springframework.web.context.ContextLoaderListener

--- a/location-finder-home/pom.xml
+++ b/location-finder-home/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.integration.demo</groupId>

--- a/location-finder-home/src/main/resources/app-context.xml
+++ b/location-finder-home/src/main/resources/app-context.xml
@@ -7,13 +7,13 @@
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
 	xmlns:cloud="http://schema.cloudfoundry.org/spring"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
-		http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
-		http://schema.cloudfoundry.org/spring http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
+		http://www.springframework.org/schema/integration/amqp https://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
+		http://schema.cloudfoundry.org/spring https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int:channel id="searchCriteriaRecieveChannel"/>
 	
@@ -49,7 +49,7 @@
 
 	<!-- CLOUD -->
 	<beans profile="cloud">
-		<int-http:outbound-gateway url="http://location-finder-form.cloudfoundry.com/service/searchForm?formName={formName}"
+		<int-http:outbound-gateway url="https://location-finder-form.cloudfoundry.com/service/searchForm?formName={formName}"
 								request-channel="searchFormReceiveChannel" 
 								http-method="GET" 
 								request-timeout="5000"
@@ -57,7 +57,7 @@
 			<int-http:uri-variable name="formName" expression="payload"/>
 		</int-http:outbound-gateway>
 	
-		<int-http:outbound-gateway url="http://location-finder.cloudfoundry.com/service/searchItem?itemName={itemName}"
+		<int-http:outbound-gateway url="https://location-finder.cloudfoundry.com/service/searchItem?itemName={itemName}"
 									request-channel="searchCriteriaOutputChannel" 
 									http-method="GET"
 									request-timeout="5000"

--- a/location-finder-home/src/main/resources/servlet-config.xml
+++ b/location-finder-home/src/main/resources/servlet-config.xml
@@ -6,12 +6,12 @@
 	xmlns:task="http://www.springframework.org/schema/task"
 	xmlns:int-channel-registry="http://www.springframework.org/schema/integration/registry"
 	xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration/registry http://www.springframework.org/schema/integration/registry/spring-integration-registry-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/registry https://www.springframework.org/schema/integration/registry/spring-integration-registry-2.0.xsd">
 
 	<int-http:inbound-gateway request-channel="searchCriteriaRecieveChannel" 
 							  supported-methods="GET"

--- a/location-finder-home/src/main/webapp/WEB-INF/web.xml
+++ b/location-finder-home/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
+<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
   <listener>
     <listener-class>
 			org.springframework.web.context.ContextLoaderListener

--- a/location-finder-node/node_modules/amqp/amqp-0-9-1.xml
+++ b/location-finder-node/node_modules/amqp/amqp-0-9-1.xml
@@ -116,7 +116,7 @@
 
     Links to full AMQP specification:
     =================================
-    http://www.amqp.org
+    https://www.amqp.org
 -->
 
 <!--

--- a/location-finder/pom.xml
+++ b/location-finder/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.integration.demo</groupId>

--- a/location-finder/src/main/resources/servlet-config.xml
+++ b/location-finder/src/main/resources/servlet-config.xml
@@ -7,13 +7,13 @@
 	xmlns:rabbit="http://www.springframework.org/schema/rabbit"
 	xmlns:int-amqp="http://www.springframework.org/schema/integration/amqp"
 	xmlns:cloud="http://schema.cloudfoundry.org/spring"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
-		http://www.springframework.org/schema/integration/amqp http://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
-		http://schema.cloudfoundry.org/spring http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration-2.0.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task-3.0.xsd
-		http://www.springframework.org/schema/rabbit http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd
+		http://www.springframework.org/schema/integration/amqp https://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd
+		http://schema.cloudfoundry.org/spring https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration-2.0.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task-3.0.xsd
+		http://www.springframework.org/schema/rabbit https://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int-http:inbound-gateway request-channel="requestReceiveChannel"
 			name="/searchItem"			
@@ -31,7 +31,7 @@
 	
 	<int-http:outbound-gateway id="locationImageGateway"
 	                           request-channel="requestChannel" 
-					           url="http://maps.google.com/maps/api/staticmap?center={center}&amp;zoom={zoom}&amp;size={size}&amp;sensor={sensor}&amp;markers=color:blue|label:S|{label}&amp;maptype=hybrid"
+					           url="https://maps.google.com/maps/api/staticmap?center={center}&amp;zoom={zoom}&amp;size={size}&amp;sensor={sensor}&amp;markers=color:blue|label:S|{label}&amp;maptype=hybrid"
 					           http-method="GET"
 					           request-timeout="5000"
 					           mapped-request-headers="Content-Type"

--- a/location-finder/src/main/webapp/WEB-INF/web.xml
+++ b/location-finder/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
+<web-app xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:web="https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="3.0">
   <context-param>
     <param-name>spring.profiles.default</param-name>
     <param-value>cloud</param-value>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.integration.demo</groupId>
     <artifactId>protocol-fallback-demo</artifactId>
@@ -148,17 +148,17 @@
         <repository>
             <id>repository.springframework.maven.release</id>
             <name>Spring Framework Maven Release Repository</name>
-            <url>http://maven.springframework.org/release</url>
+            <url>https://maven.springframework.org/release</url>
         </repository>
         <repository>
             <id>repository.springframework.maven.milestone</id>
             <name>Spring Framework Maven Milestone Repository</name>
-            <url>http://maven.springframework.org/milestone</url>
+            <url>https://maven.springframework.org/milestone</url>
         </repository>
         <repository>
             <id>repository.springframework.maven.snapshot</id>
             <name>Spring Framework Maven Snapshot Repository</name>
-            <url>http://maven.springframework.org/snapshot</url>
+            <url>https://maven.springframework.org/snapshot</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://location-finder-form.cloudfoundry.com/service/searchForm?formName= (UnknownHostException) with 1 occurrences migrated to:  
  https://location-finder-form.cloudfoundry.com/service/searchForm?formName= ([https](https://location-finder-form.cloudfoundry.com/service/searchForm?formName=) result UnknownHostException).
* http://location-finder.cloudfoundry.com/service/searchItem?itemName= (UnknownHostException) with 1 occurrences migrated to:  
  https://location-finder.cloudfoundry.com/service/searchItem?itemName= ([https](https://location-finder.cloudfoundry.com/service/searchItem?itemName=) result UnknownHostException).
* http://maps.google.com/maps/api/staticmap?center= (400) with 1 occurrences migrated to:  
  https://maps.google.com/maps/api/staticmap?center= ([https](https://maps.google.com/maps/api/staticmap?center=) result 400).
* http://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd (404) with 3 occurrences migrated to:  
  https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd ([https](https://schema.cloudfoundry.org/spring/cloudfoundry-spring-0.6.xsd) result 404).
* http://www.springframework.org/schema/integration/registry/spring-integration-registry-2.0.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/registry/spring-integration-registry-2.0.xsd ([https](https://www.springframework.org/schema/integration/registry/spring-integration-registry-2.0.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.amqp.org with 1 occurrences migrated to:  
  https://www.amqp.org ([https](https://www.amqp.org) result 200).
* http://www.springframework.org/schema/aop/spring-aop-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-3.1.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-3.1.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd ([https](https://www.springframework.org/schema/integration/amqp/spring-integration-amqp-2.1.xsd) result 200).
* http://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd ([https](https://www.springframework.org/schema/integration/http/spring-integration-http-2.0.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration-2.0.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration-2.0.xsd ([https](https://www.springframework.org/schema/integration/spring-integration-2.0.xsd) result 200).
* http://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd ([https](https://www.springframework.org/schema/rabbit/spring-rabbit-1.0.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task-3.0.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task-3.0.xsd ([https](https://www.springframework.org/schema/task/spring-task-3.0.xsd) result 200).
* http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd with 3 occurrences migrated to:  
  https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd ([https](https://java.sun.com/xml/ns/javaee/web-app_2_5.xsd) result 302).
* http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release with 1 occurrences migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://maven.springframework.org/snapshot with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/javaee with 3 occurrences
* http://localhost:8080/location-finder-form/service/searchForm?formName= with 1 occurrences
* http://localhost:8080/location-finder/service/searchItem?itemName= with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://schema.cloudfoundry.org/spring with 6 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/beans with 10 occurrences
* http://www.springframework.org/schema/integration with 8 occurrences
* http://www.springframework.org/schema/integration/amqp with 6 occurrences
* http://www.springframework.org/schema/integration/http with 10 occurrences
* http://www.springframework.org/schema/integration/registry with 2 occurrences
* http://www.springframework.org/schema/rabbit with 6 occurrences
* http://www.springframework.org/schema/task with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 9 occurrences